### PR TITLE
gitignore: add SQLite WAL and SHM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.sqlite
 *.sqlite3
-*.sqlite3-shm
-*.sqlite3-wal
 *.db
 *.csv
-*.db-shm
-*.db-wal
+*.*-shm
+*.*-wal

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.sqlite
 *.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
 *.db
 *.csv
 *.db-shm


### PR DESCRIPTION
This PR adds `*.sqlite3-shm` and `*.sqlite3-wal` to the `.gitignore` file to prevent accidentally committing SQLite's write-ahead log and shared memory files.